### PR TITLE
Fix test by importing re-exported proptest macro

### DIFF
--- a/tests/model.rs
+++ b/tests/model.rs
@@ -1,4 +1,4 @@
-use model::{linearizable, model};
+use model::*;
 
 #[test]
 fn test_model() {


### PR DESCRIPTION
I ran into the same issue as in #1, I found I was able to fix it by importing the proptest macros inside the test module. It's possible there may be a way to redesign the macros to avoid the need for this, perhaps by evaluating `prop_oneof!` before quoting, but that's beyond my ken.